### PR TITLE
Feature/get original routing key

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -488,10 +488,19 @@ func (c *Consumer) deliver(
 		if err != nil {
 			return fmt.Errorf("deadletter after delivery limit: %w", err)
 		}
+
+		return nil
 	}
 
+	var de *DeadletterError
+
 	err := c.handler(subCtx, delivery)
-	if err != nil {
+	if errors.As(err, &de) {
+		err := c.deadletterDelivery(ctx, delivery)
+		if err != nil {
+			return fmt.Errorf("deadletter after DeadletterError: %w", err)
+		}
+	} else if err != nil {
 		return err
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -528,8 +528,8 @@ func (c *Consumer) deadletterDelivery(
 	// that rabbit uses when deadlettering.
 	_, exists := newHead["old-death"]
 	if !exists {
-		newHead["old-death"] = []amqp.Table{
-			{
+		newHead["old-death"] = []interface{}{
+			amqp.Table{
 				"count":        1,
 				"exchange":     c.exchangeName,
 				"queue":        c.queueName,

--- a/consumer.go
+++ b/consumer.go
@@ -534,7 +534,7 @@ func (c *Consumer) deadletterDelivery(
 				"exchange":     c.exchangeName,
 				"queue":        c.queueName,
 				"reason":       "rejected",
-				"routing-keys": []string{delivery.RoutingKey},
+				"routing-keys": []interface{}{delivery.RoutingKey},
 				"time":         time.Now(),
 			},
 		}

--- a/error.go
+++ b/error.go
@@ -84,3 +84,13 @@ func tErrorf(code TransitionCode, format string, a ...any) *transitionError {
 		msg:   err.Error(),
 	}
 }
+
+func NewDeadletterError() error {
+	return &DeadletterError{}
+}
+
+type DeadletterError struct{}
+
+func (he *DeadletterError) Error() string {
+	return "deadletter message"
+}


### PR DESCRIPTION
If messages are automatically retried or shoveled from a dead-letter queue, the original routing key gets replaced and is stored in headers instead of the top-level "RoutingKey" field.